### PR TITLE
Update core.py to support python3.9

### DIFF
--- a/airsensor/core.py
+++ b/airsensor/core.py
@@ -23,6 +23,6 @@ class AirSensor(object):
         n = self.dev.write(0x02, cmd, timeout=10000)
 
         arr = self.dev.read(0x081, size_or_buffer=0x10, timeout=10000)
-        voc = int.from_bytes(arr.tostring()[2:4], byteorder="little")
+        voc = int.from_bytes(arr[2:4], byteorder="little")
 
         return voc


### PR DESCRIPTION
remove .tostring() to support python3.9. See also https://docs.python.org/3.9/whatsnew/3.9.html#removed